### PR TITLE
coin-qt.pro update for Windows Build

### DIFF
--- a/coin-qt.pro
+++ b/coin-qt.pro
@@ -27,10 +27,10 @@ windows:LIBS += -lshlwapi
 Windows:LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
 windows:LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 windows:LIBS += -lws2_32 -lole32 -loleaut32 -luuid -lgdi32
-windows:LIBS += -lboost_system-mgw49-mt-s-1_62 -lboost_filesystem-mgw49-mt-s-1_62 -lboost_program_options-mgw49-mt-s-1_62 -lboost_thread-mgw49-mt-s-1_62
-windows:BOOST_LIB_SUFFIX=-mgw49-mt-s-1_62
-windows:BOOST_INCLUDE_PATH=C:/deps/boost_1_62_0
-windows:BOOST_LIB_PATH=C:/deps/boost_1_62_0/stage/lib
+windows:LIBS += -lboost_system-mgw73-mt-s-1_65 -lboost_filesystem-mgw73-mt-s-1_65 -lboost_program_options-mgw73-mt-s-1_65 -lboost_thread-mgw73-mt-s-1_65
+windows:BOOST_LIB_SUFFIX=-mgw73-mt-s-1_65
+windows:BOOST_INCLUDE_PATH=C:/deps/boost_1_65_0
+windows:BOOST_LIB_PATH=C:/deps/boost_1_65_0/stage/lib
 windows:BDB_INCLUDE_PATH=c:/deps/db-4.8.30.NC/build_unix
 windows:BDB_LIB_PATH=c:/deps/db-4.8.30.NC/build_unix
 windows:OPENSSL_INCLUDE_PATH=c:/deps/openssl-1.0.2q/include
@@ -40,6 +40,7 @@ windows:MINIUPNPC_LIB_PATH=C:/deps/miniupnpc
 windows:QRENCODE_INCLUDE_PATH=C:/deps/qrencode-4.0.2
 windows:QRENCODE_LIB_PATH=C:/deps/qrencode-4.0.2/.libs
 # qrencode-4.0.2. depends on Libpng-1.6.36. (http://www.libpng.org/pub/png/libpng.html)
+# libpng-1.6.36. it needs to be compiled with MinGW (gcc) 4.9.4 or lower
 
 OBJECTS_DIR = build
 MOC_DIR = build
@@ -454,7 +455,7 @@ LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
 windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_LIB_SUFFIX
 windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 
 contains(RELEASE, 1) {


### PR DESCRIPTION
Update for Windows Build

- Python 3.3.
- Perl 5.18.
- GCC: MinGW i686-7.3.0-posix-dwarf-rt_v5-rev0.
- Boost 1.65.0.
- Berkeley DB 4.8.30.NC.
- Miniupnpc-1.9.
- Openssl-1.0.2q.
- Libpng-1.6.36. (MinGW 4.9.4)
- Qrencode-4.0.2.
- Qt 5.2.0.

libpng-1.6.36. it needs to be compiled with MinGW (gcc) 4.9.4 or lower.